### PR TITLE
Add Title Screen, Quit Button, and Money Reset on New Game

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,15 +5,18 @@ import Hand from "./components/Hand"
 import BettingPanel from "./components/BettingPanel"
 import GameControls from "./components/GameControls"
 import GameMessage from "./components/GameMessage"
+import TitleScreen from "./components/TitleScreen" // New component to add
 import { createNewDeck, drawCards } from "./utils/deckApi"
 import { calculateHandValue, isBlackjack, isBust, shouldDealerHit, determineWinner } from "./utils/gameLogic"
 import "./App.css"
 
 function App() {
+  const INITIAL_MONEY = 1000
+  const [showTitle, setShowTitle] = useState(true)
   const [deckId, setDeckId] = useState(null)
   const [playerCards, setPlayerCards] = useState([])
   const [dealerCards, setDealerCards] = useState([])
-  const [money, setMoney] = useState(1000)
+  const [money, setMoney] = useState(INITIAL_MONEY)
   const [currentBet, setCurrentBet] = useState(0)
   const [gameState, setGameState] = useState("betting") // 'betting', 'playing', 'dealerTurn', 'gameOver'
   const [message, setMessage] = useState("")
@@ -32,6 +35,17 @@ function App() {
       setMessage("Failed to initialize game. Please refresh.")
       setMessageType("error")
     }
+  }
+
+  const startGame = () => {
+    setMoney(INITIAL_MONEY)
+    setShowTitle(false)
+    newGame()
+  }
+
+  const quitGame = () => {
+    setShowTitle(true)
+    newGame()
   }
 
   const placeBet = async (betAmount) => {
@@ -153,6 +167,12 @@ function App() {
 
   const canHit = gameState === "playing" && !isBust(playerCards) && calculateHandValue(playerCards) < 21
 
+  if (showTitle) {
+    return (
+      <TitleScreen onStart={startGame} />
+    )
+  }
+
   return (
     <div className="app minimalist">
       <div className="center-title">
@@ -169,6 +189,7 @@ function App() {
         </aside>
         <div className="game-center">
           <header className="game-header minimalist-header">
+            <button className="quit-btn" onClick={quitGame}>Quit</button>
           </header>
           <div className="game-area minimalist-area">
             <Hand
@@ -192,12 +213,13 @@ function App() {
             <p>You're out of money!</p>
             <button
               onClick={() => {
-                setMoney(1000)
+                setMoney(INITIAL_MONEY)
                 newGame()
+                setShowTitle(true)
               }}
               className="restart-btn"
             >
-              Start New Game ($1000)
+              Start New Game (${INITIAL_MONEY})
             </button>
           </div>
         </div>

--- a/src/components/GameControls.jsx
+++ b/src/components/GameControls.jsx
@@ -1,6 +1,15 @@
 "use client"
 
-const GameControls = ({ onHit, onStand, onNewGame, gameState, canHit }) => {
+const GameControls = ({
+  onHit,
+  onStand,
+  onSplit,
+  onDoubleDown,
+  gameState,
+  canHit,
+  canSplit,
+  canDoubleDown,
+}) => {
   return (
     <div className="game-controls">
       {gameState === "playing" && (
@@ -11,6 +20,18 @@ const GameControls = ({ onHit, onStand, onNewGame, gameState, canHit }) => {
           <button onClick={onStand} className="control-btn stand-btn">
             Stand
           </button>
+
+          {canSplit && (
+            <button onClick={onSplit} className="control-btn split-btn">
+              Split
+            </button>
+          )}
+
+          {canDoubleDown && (
+            <button onClick={onDoubleDown} className="control-btn double-down-btn">
+              Double Down
+            </button>
+          )}
         </>
       )}
 

--- a/src/components/GameControls.jsx
+++ b/src/components/GameControls.jsx
@@ -3,8 +3,10 @@
 const GameControls = ({
   onHit,
   onStand,
+  onNewGame,
   onSplit,
   onDoubleDown,
+  onQuit,
   gameState,
   canHit,
   canSplit,
@@ -32,6 +34,10 @@ const GameControls = ({
               Double Down
             </button>
           )}
+
+          <button onClick={onQuit} className="control-btn quit-btn">
+            Quit
+          </button>
         </>
       )}
 

--- a/src/components/Hand.jsx
+++ b/src/components/Hand.jsx
@@ -1,7 +1,14 @@
 import Card from "./Card"
 import { calculateHandValue } from "../utils/gameLogic"
 
-const Hand = ({ cards, title, hideFirstCard = false, showValue = true }) => {
+const Hand = ({
+  cards,
+  title,
+  hideFirstCard = false,
+  showValue = true,
+  isActiveHand = false,
+  handIndex = 0,
+}) => {
   const visibleCards = hideFirstCard ? cards.slice(1) : cards
   const handValue = hideFirstCard
     ? cards.length > 1
@@ -9,14 +16,21 @@ const Hand = ({ cards, title, hideFirstCard = false, showValue = true }) => {
       : "?"
     : calculateHandValue(cards)
 
+  // Example: Highlight active hand in split situation
+  const activeClass = isActiveHand ? "active-hand" : ""
+
   return (
-    <div className="hand">
+    <div className={`hand ${activeClass}`}>
       <div className="hand-title">
         {title} {showValue && `(${handValue})`}
       </div>
       <div className="cards-container">
         {cards.map((card, index) => (
-          <Card key={`${card.suit}-${card.value}-${index}`} card={card} hidden={hideFirstCard && index === 0} />
+          <Card
+            key={`${card.suit}-${card.value}-${index}-${handIndex}`}
+            card={card}
+            hidden={hideFirstCard && index === 0}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
This PR implements the Title Screen with a fade-in animated title and start button. It adds a Quit button during gameplay to return to the Title Screen. On starting a new game, players receive the initial money amount reset to ensure fair play each session. Additionally, when players run out of money, a game over popup appears with an option to start fresh and return to the Title Screen. These features improve user experience by providing clear game flow control and consistent money management.

Closes #2